### PR TITLE
Modify vite.config.ts for adding base url for github pages

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,15 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-// https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [react()],
+export default defineConfig(({mode }) => {
+  let base = "/"
+
+  if (mode === "repo") {
+    base = "//sample-visualization-of-flexmatch-rule/"
+  }
+
+  return {
+    plugins: [react()],
+    base: base,
+  };
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ export default defineConfig(({mode }) => {
   let base = "/"
 
   if (mode === "repo") {
-    base = "//sample-visualization-of-flexmatch-rule/"
+    base = "/sample-visualization-of-flexmatch-rule/"
   }
 
   return {


### PR DESCRIPTION
*Issue #4 , if available:*

*Description of changes:*
To add base URL for github pages, configure `vite.config.ts` for adding base url when mode param is passed by github actions runner.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
