### PR TITLE
fix: 🐛 Failed to load JSON rules when deploy on github pages

### DIFF
--- a/src/components/editor/PresetFlexMatchRuleLoader.tsx
+++ b/src/components/editor/PresetFlexMatchRuleLoader.tsx
@@ -2,7 +2,7 @@ import { RuleSet } from "../../utils/definitions";
 
 export async function loadPresetFlexMatchRule(jsonFileName: string): Promise<RuleSet> {
   try {
-    const response = await fetch(`/jsonRules/${jsonFileName}`);
+    const response = await fetch(`${import.meta.env.BASE_URL}jsonRules/${jsonFileName}`);
     if (!response.ok) {
       throw new Error(`HTTP error! Status: ${response.status}`);
     }


### PR DESCRIPTION
*Issue #6 , if available:*

*Description of changes:*
I fixed PresetFlexMatchRUleLoader for use baseURL.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
